### PR TITLE
Removing an annoying warn when launching test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name" : "grunt-jasmine-node-new",
+  "name" : "grunt-jasmine-node",
   "description" : "Grunt task for running jasmine-node",
   "version" : "0.3.2",
   "homepage" : "https://github.com/lennym/grunt-jasmine-node",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {},
   "dependencies": {
-    "jasmine-node": "2.0.0-beta4",
+     "jasmine-node": "~1.14.0",
     "coffee-script": "1.10.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   },
   "scripts": {},
   "dependencies": {
-    "jasmine-node": "~1.14.5",
-    "coffee-script": "~1.9.1"
+    "jasmine-node": "2.0.0-beta4",
+    "coffee-script": "latest"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-contrib-jshint": "~0.1.1"
+    "grunt": "~0.4.5",
+    "grunt-contrib-jshint": "latest"
   },
   "keywords": [
     "gruntplugin",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name" : "grunt-jasmine-node",
   "description" : "Grunt task for running jasmine-node",
-  "version" : "0.3.2",
+  "version" : "0.3.3",
   "homepage" : "https://github.com/lennym/grunt-jasmine-node",
   "author" : {
     "name" : "Omar Gonzalez",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "scripts": {},
   "dependencies": {
     "jasmine-node": "2.0.0-beta4",
-    "coffee-script": "latest"
+    "coffee-script": "1.10.0"
   },
   "devDependencies": {
     "grunt": "~0.4.5",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {},
   "dependencies": {
-     "jasmine-node": "~1.14.0",
+      "jasmine-node": "3.0.0",
     "coffee-script": "1.10.0"
   },
   "devDependencies": {

--- a/tasks/jasmine-node-task.js
+++ b/tasks/jasmine-node-task.js
@@ -47,7 +47,7 @@ module.exports = function (grunt) {
 
       var onComplete = function(runner, log) {
         var exitCode;
-        util.print('\n');
+        console.log('\n');
         if (runner.results().failedCount === 0) {
           exitCode = 0;
         } else {


### PR DESCRIPTION
Stop the "util.print: Use console.log instead" message
